### PR TITLE
feat: freee テンプレートIDを組織設定で管理

### DIFF
--- a/app/lib/auth-helpers.server.ts
+++ b/app/lib/auth-helpers.server.ts
@@ -11,6 +11,7 @@ interface OrgContext {
     name: string
     slug: string | null
     freeeCompanyId: number | null
+    freeeTemplateId: number | null
   }
   membership: {
     id: string
@@ -64,6 +65,7 @@ export async function requireOrgMember(
       'organization.name as orgName',
       'organization.slug as orgSlug',
       'organization.freeeCompanyId',
+      'organization.freeeTemplateId',
       'member.id as memberId',
       'member.role',
     ])
@@ -82,6 +84,7 @@ export async function requireOrgMember(
       name: result.orgName,
       slug: result.orgSlug,
       freeeCompanyId: result.freeeCompanyId,
+      freeeTemplateId: result.freeeTemplateId,
     },
     membership: {
       id: result.memberId,

--- a/app/lib/db/types.ts
+++ b/app/lib/db/types.ts
@@ -165,6 +165,7 @@ export interface MonthlyStatus {
 export interface Organization {
   createdAt: Generated<string>;
   freeeCompanyId: number | null;
+  freeeTemplateId: number | null;
   id: string;
   logo: string | null;
   metadata: string | null;

--- a/app/routes/org.$orgSlug/invoices/create.tsx
+++ b/app/routes/org.$orgSlug/invoices/create.tsx
@@ -199,7 +199,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     // 共通の deps（PDF は今回使わないので除外）
     const baseDeps = {
       getCompanyId: () => freeeCompanyId,
-      getTemplateId: () => Number(process.env.FREEE_TEMPLATE_ID),
+      getTemplateId: () => organization.freeeTemplateId,
       getTotalHours: () => totalHours,
       getPreviousInvoice: async () => {
         if (!client.freeePartnerId) return null

--- a/app/routes/org.$orgSlug/settings/freee.tsx
+++ b/app/routes/org.$orgSlug/settings/freee.tsx
@@ -56,10 +56,21 @@ const setCompanySchema = z.object({
   freeeCompanyId: z.coerce.number().int().positive(),
 })
 
+const fetchTemplatesSchema = z.object({
+  intent: z.literal('fetchTemplates'),
+})
+
+const setTemplateSchema = z.object({
+  intent: z.literal('setTemplate'),
+  freeeTemplateId: z.coerce.number().int().positive(),
+})
+
 const formSchema = z.discriminatedUnion('intent', [
   authCodeSchema,
   fetchCompaniesSchema,
   setCompanySchema,
+  fetchTemplatesSchema,
+  setTemplateSchema,
 ])
 
 export const handle = {
@@ -164,6 +175,42 @@ export async function action({ request, params }: Route.ActionArgs) {
     return { lastResult: submission.reply(), companySet: true }
   }
 
+  if (intent === 'fetchTemplates') {
+    if (!organization.freeeCompanyId) {
+      return {
+        lastResult: submission.reply({
+          formErrors: ['先に会社を設定してください'],
+        }),
+      }
+    }
+    try {
+      const freee = await getFreeeClientForOrganization(organization.id)
+      const { templates } = await freee.getInvoiceTemplates(
+        organization.freeeCompanyId,
+      )
+      return { lastResult: submission.reply(), templates }
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'freee API エラー'
+      return {
+        lastResult: submission.reply({ formErrors: [message] }),
+      }
+    }
+  }
+
+  if (intent === 'setTemplate') {
+    const { freeeTemplateId } = submission.value
+    const now = new Date().toISOString()
+
+    await db
+      .updateTable('organization')
+      .set({ freeeTemplateId, updatedAt: now })
+      .where('id', '=', organization.id)
+      .execute()
+
+    return { lastResult: submission.reply(), templateSet: true }
+  }
+
   return { lastResult: submission.reply() }
 }
 
@@ -174,6 +221,8 @@ export default function FreeeSettings({
 
   const companies =
     actionData && 'companies' in actionData ? actionData.companies : null
+  const templates =
+    actionData && 'templates' in actionData ? actionData.templates : null
   const isAuthenticated =
     hasToken ||
     (actionData && 'authenticated' in actionData && actionData.authenticated)
@@ -299,6 +348,82 @@ export default function FreeeSettings({
           ) : (
             <p className="text-muted-foreground ml-7 text-sm">
               まず freee 認証を完了してください
+            </p>
+          )}
+        </div>
+        {/* ステップ3: テンプレート選択 */}
+        <div className="space-y-3">
+          <div className="flex items-center gap-2">
+            {organization.freeeTemplateId ? (
+              <CheckCircle2Icon className="h-5 w-5 text-emerald-600" />
+            ) : (
+              <span className="bg-muted flex h-5 w-5 items-center justify-center rounded-full text-xs font-medium">
+                3
+              </span>
+            )}
+            <h4 className="font-medium">請求書テンプレートを選択</h4>
+            {organization.freeeTemplateId && (
+              <Badge variant="outline" className="text-emerald-600">
+                設定済み (ID: {organization.freeeTemplateId})
+              </Badge>
+            )}
+          </div>
+          {organization.freeeCompanyId ? (
+            <div className="ml-7 space-y-3">
+              <p className="text-muted-foreground text-sm">
+                請求書作成時に使用するテンプレートを選択します。
+              </p>
+              <Form method="POST">
+                <input type="hidden" name="intent" value="fetchTemplates" />
+                <Button type="submit" variant="outline" size="sm">
+                  <RefreshCwIcon className="mr-2 h-4 w-4" />
+                  テンプレート一覧を取得
+                </Button>
+              </Form>
+
+              {templates && templates.length > 0 && (
+                <Form method="POST" className="flex items-end gap-2">
+                  <input type="hidden" name="intent" value="setTemplate" />
+                  <div className="flex-1">
+                    <Select name="freeeTemplateId">
+                      <SelectTrigger>
+                        <SelectValue placeholder="テンプレートを選択" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {templates.map((template) => (
+                          <SelectItem
+                            key={template.id}
+                            value={template.id.toString()}
+                          >
+                            {template.name} (ID: {template.id})
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <Button type="submit" size="sm">
+                    設定
+                  </Button>
+                </Form>
+              )}
+
+              {templates && templates.length === 0 && (
+                <p className="text-muted-foreground text-sm">
+                  テンプレートが見つかりませんでした
+                </p>
+              )}
+
+              {actionData &&
+                'templateSet' in actionData &&
+                actionData.templateSet && (
+                  <p className="text-sm text-emerald-600">
+                    テンプレートを設定しました
+                  </p>
+                )}
+            </div>
+          ) : (
+            <p className="text-muted-foreground ml-7 text-sm">
+              まず会社を設定してください
             </p>
           )}
         </div>

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -59,6 +59,7 @@ CREATE TABLE IF NOT EXISTS "organization" (
   "logo" TEXT,
   "metadata" TEXT,
   "freee_company_id" INTEGER,
+  "freee_template_id" INTEGER,
   "created_at" TEXT NOT NULL DEFAULT (datetime('now')),
   "updated_at" TEXT NOT NULL DEFAULT (datetime('now'))
 );

--- a/src/services/invoice-service.ts
+++ b/src/services/invoice-service.ts
@@ -74,7 +74,7 @@ export type InvoiceApiResult = {
 
 export type InvoiceDeps = {
   getCompanyId: () => number
-  getTemplateId: () => number
+  getTemplateId: () => number | null
   getTotalHours: () => number
   getPreviousInvoice: () => Promise<PreviousInvoice | null>
   createInvoice: (params: InvoiceApiParams) => Promise<InvoiceApiResult>
@@ -199,7 +199,7 @@ async function buildInvoiceParams(
 
   const params: InvoiceApiParams = {
     company_id: companyId,
-    template_id: templateId,
+    ...(templateId != null && { template_id: templateId }),
     billing_date: getBillingDate(year, month),
     payment_date: getPaymentDate(year, month, client.paymentTerms),
     partner_id: client.freeePartnerId,


### PR DESCRIPTION
## Summary
- 環境変数 `FREEE_TEMPLATE_ID` への依存を廃止し、freee API からテンプレート一覧を取得して組織ごとに設定・保存できるようにした
- freee 連携設定ページにステップ3「テンプレート選択」を追加
- テンプレート未設定時は `template_id` を送信せず freee デフォルトを使用

## Test plan
- [ ] `pnpm db:push` でスキーマ反映
- [ ] freee 設定ページ > テンプレート一覧取得 > 選択 > 保存を確認
- [ ] 請求書作成が正常に動作することを確認（テンプレート設定済み / 未設定両方）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organizations can now store and manage their own Freee invoice template ID.
  * Added a new template selection interface in Freee settings, allowing users to fetch and select from available Freee invoice templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->