### PR TITLE
fix: playground autosave のデバウンスを 500ms → 0ms に変更

### DIFF
--- a/app/routes/playground/+components/use-auto-save.ts
+++ b/app/routes/playground/+components/use-auto-save.ts
@@ -44,7 +44,7 @@ export function useAutoSave(store: TimesheetStoreApi, monthKey: string) {
         return
 
       if (timeoutRef.current) clearTimeout(timeoutRef.current)
-      timeoutRef.current = setTimeout(flush, 500)
+      timeoutRef.current = setTimeout(flush, 0)
     })
 
     return () => {


### PR DESCRIPTION
## Summary
- localStorage への書き込みは即時完了するためデバウンス不要
- work-hours 版と同じ `setTimeout(flush, 0)` に統一

#19 マージ後の追加修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-save responsiveness by reducing the save delay, ensuring changes are persisted faster when edits are made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->